### PR TITLE
Implement ios group media wallet ui

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import AppHome from "./pages/app/AppHome";
 import Chats from "./pages/app/Chats";
 import Wallet from "./pages/app/Wallet";
 import Rooms from "./pages/app/Rooms";
+import Groups from "./pages/app/Groups";
+import Media from "./pages/app/Media";
 import Events from "./pages/app/Events";
 import Business from "./pages/app/Business";
 import Navigation from "./components/Navigation";
@@ -29,6 +31,8 @@ const App = () => (
             <Route path="chats" element={<Chats />} />
             <Route path="wallet" element={<Wallet />} />
             <Route path="rooms" element={<Rooms />} />
+            <Route path="groups" element={<Groups />} />
+            <Route path="media" element={<Media />} />
             <Route path="events" element={<Events />} />
             <Route path="business" element={<Business />} />
           </Route>

--- a/src/pages/app/AppHome.tsx
+++ b/src/pages/app/AppHome.tsx
@@ -12,7 +12,8 @@ import {
   ArrowRight,
   AlertTriangle,
   Coins,
-  Clock
+  Clock,
+  Image as ImageIcon
 } from "lucide-react";
 import { Link } from "react-router-dom";
 
@@ -20,8 +21,8 @@ const AppHome = () => {
   const quickActions = [
     { icon: MessageCircle, label: "Chats", path: "/app/chats", color: "primary" },
     { icon: Wallet, label: "Wallet", path: "/app/wallet", color: "community" },
-    { icon: Users, label: "Rooms", path: "/app/rooms", color: "secondary" },
-    { icon: Shield, label: "Safety", path: "/app/rooms", color: "destructive" },
+    { icon: Users, label: "Groups", path: "/app/groups", color: "secondary" },
+    { icon: ImageIcon, label: "Media", path: "/app/media", color: "primary" },
     { icon: Calendar, label: "Events", path: "/app/events", color: "primary" },
     { icon: Store, label: "Business", path: "/app/business", color: "community" }
   ];

--- a/src/pages/app/Groups.tsx
+++ b/src/pages/app/Groups.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import AppHeader from "@/components/AppHeader";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Users, Shield, Briefcase, GraduationCap, FileText, Plus, Search } from "lucide-react";
+
+type Group = {
+  id: number;
+  name: string;
+  description: string;
+  members: number;
+  verified?: boolean;
+  category: "community" | "safety" | "employment" | "education" | "business" | "stokvel" | "personal";
+  unread?: number;
+};
+
+const groupsSeed: Group[] = [
+  { id: 1, name: "Ward 12 CPF", description: "Community policing forum updates", members: 2450, verified: true, category: "safety", unread: 3 },
+  { id: 2, name: "Thabo's Stokvel", description: "Monthly savings circle", members: 12, verified: true, category: "stokvel", unread: 1 },
+  { id: 3, name: "Jobs Room", description: "Local job posts and career help", members: 1820, verified: true, category: "employment" },
+  { id: 4, name: "Education Room", description: "Courses, bursaries and tips", members: 3100, verified: true, category: "education" },
+  { id: 5, name: "Sonto (Neighbor)", description: "Personal chat", members: 2, category: "personal" },
+  { id: 6, name: "SMME Tenders", description: "Business tenders and notices", members: 890, verified: true, category: "business" },
+];
+
+const categoryToIcon: Record<string, any> = {
+  safety: Shield,
+  employment: Briefcase,
+  education: GraduationCap,
+  business: FileText,
+  community: Users,
+  stokvel: Users,
+  personal: Users,
+};
+
+const Groups = () => {
+  const [query, setQuery] = useState("");
+
+  const filtered = groupsSeed.filter((g) => g.name.toLowerCase().includes(query.toLowerCase()));
+
+  const renderGroupCard = (group: Group) => {
+    const Icon = categoryToIcon[group.category] || Users;
+    return (
+      <Card key={group.id} className="p-4 bg-card/80 backdrop-blur-sm hover:shadow-lg transition-all duration-300">
+        <div className="flex items-center gap-4">
+          <div className="w-12 h-12 rounded-xl bg-primary/10 text-primary border border-primary/20 flex items-center justify-center">
+            <Icon className="w-6 h-6" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <h4 className="font-semibold text-foreground truncate">{group.name}</h4>
+              {group.verified && (
+                <Badge className="bg-primary text-primary-foreground">Verified</Badge>
+              )}
+            </div>
+            <p className="text-sm text-muted-foreground truncate">{group.description}</p>
+            <div className="text-xs text-muted-foreground mt-1">{group.members.toLocaleString()} members</div>
+          </div>
+          <div className="flex flex-col items-end gap-2">
+            {group.unread ? (
+              <Badge className="bg-primary text-primary-foreground">{group.unread}</Badge>
+            ) : null}
+            <Button variant="outline" size="sm">Join</Button>
+          </div>
+        </div>
+      </Card>
+    );
+  };
+
+  const sections: { key: string; label: string; filter: (g: Group) => boolean }[] = [
+    { key: "all", label: "All", filter: () => true },
+    { key: "stokvel", label: "Stokvels", filter: (g) => g.category === "stokvel" },
+    { key: "community", label: "Community", filter: (g) => ["community", "safety"].includes(g.category) },
+    { key: "work", label: "Work", filter: (g) => ["employment", "business"].includes(g.category) },
+    { key: "education", label: "Education", filter: (g) => g.category === "education" },
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-background to-accent/30 pb-20">
+      <AppHeader title="Groups" />
+
+      <div className="p-4 space-y-4">
+        <div className="flex gap-2">
+          <div className="flex-1 relative">
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="w-full rounded-lg border border-border bg-white px-10 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+              placeholder="Search groups"
+            />
+            <Search className="w-4 h-4 text-muted-foreground absolute left-3 top-2.5" />
+          </div>
+          <Button variant="hero" className="gap-2"><Plus className="w-4 h-4" /> New</Button>
+        </div>
+
+        <Tabs defaultValue="all" className="w-full">
+          <TabsList className="w-full grid grid-cols-5">
+            {sections.map((s) => (
+              <TabsTrigger key={s.key} value={s.key}>{s.label}</TabsTrigger>
+            ))}
+          </TabsList>
+          {sections.map((s) => (
+            <TabsContent key={s.key} value={s.key}>
+              <div className="space-y-2">
+                {filtered.filter(s.filter).map(renderGroupCard)}
+              </div>
+            </TabsContent>
+          ))}
+        </Tabs>
+      </div>
+    </div>
+  );
+};
+
+export default Groups;
+

--- a/src/pages/app/Media.tsx
+++ b/src/pages/app/Media.tsx
@@ -1,0 +1,153 @@
+import { useMemo, useRef, useState } from "react";
+import AppHeader from "@/components/AppHeader";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { AspectRatio } from "@/components/ui/aspect-ratio";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from "@/components/ui/carousel";
+import { Image as ImageIcon, Video, Upload, Play, Pause } from "lucide-react";
+
+type MediaItem = {
+  id: number;
+  type: "image" | "video";
+  src: string;
+  title?: string;
+  tags?: string[];
+};
+
+const seed: MediaItem[] = [
+  { id: 1, type: "image", src: "/placeholder.svg?height=600&width=800", title: "Community Clean-up" },
+  { id: 2, type: "image", src: "/placeholder.svg?height=600&width=800", title: "Youth Soccer" },
+  { id: 3, type: "video", src: "/placeholder.svg?height=600&width=800", title: "Ward Meeting Highlights" },
+  { id: 4, type: "image", src: "/placeholder.svg?height=600&width=800", title: "Local Market" },
+  { id: 5, type: "video", src: "/placeholder.svg?height=600&width=800", title: "CPF Awareness" },
+];
+
+const Media = () => {
+  const [items, setItems] = useState<MediaItem[]>(seed);
+  const [filter, setFilter] = useState<"all" | "image" | "video">("all");
+  const [uploading, setUploading] = useState(false);
+
+  const fileInput = useRef<HTMLInputElement | null>(null);
+
+  const filtered = useMemo(() => {
+    return filter === "all" ? items : items.filter((m) => m.type === filter);
+  }, [items, filter]);
+
+  const onPick = () => fileInput.current?.click();
+  const onFiles = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    if (files.length === 0) return;
+    setUploading(true);
+    // Fake client-only preview entries
+    const newItems: MediaItem[] = files.map((f, i) => ({
+      id: Date.now() + i,
+      type: f.type.startsWith("video") ? "video" : "image",
+      src: URL.createObjectURL(f),
+      title: f.name,
+    }));
+    setItems((prev) => [...newItems, ...prev]);
+    setUploading(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-background to-accent/30 pb-20">
+      <AppHeader title="Media" />
+      <div className="p-4 space-y-4">
+        <div className="flex items-center gap-2">
+          <div className="flex gap-2">
+            <Button variant={filter === "all" ? "default" : "outline"} onClick={() => setFilter("all")}>All</Button>
+            <Button variant={filter === "image" ? "default" : "outline"} onClick={() => setFilter("image")} className="gap-2">
+              <ImageIcon className="w-4 h-4" /> Photos
+            </Button>
+            <Button variant={filter === "video" ? "default" : "outline"} onClick={() => setFilter("video")} className="gap-2">
+              <Video className="w-4 h-4" /> Videos
+            </Button>
+          </div>
+          <div className="ml-auto">
+            <input ref={fileInput} type="file" className="hidden" accept="image/*,video/*" multiple onChange={onFiles} />
+            <Button variant="hero" className="gap-2" onClick={onPick} disabled={uploading}>
+              <Upload className="w-4 h-4" /> {uploading ? "Uploading..." : "Upload"}
+            </Button>
+          </div>
+        </div>
+
+        {/* Featured carousel */}
+        {filtered.length > 0 && (
+          <Carousel className="w-full">
+            <CarouselContent>
+              {filtered.slice(0, 5).map((m) => (
+                <CarouselItem key={m.id} className="md:basis-1/2 lg:basis-1/3">
+                  <Card className="p-2 bg-card/80 backdrop-blur-sm">
+                    <Dialog>
+                      <DialogTrigger asChild>
+                        <div className="cursor-pointer">
+                          <AspectRatio ratio={16 / 9}>
+                            <img src={m.src} alt={m.title} className="h-full w-full rounded-md object-cover" />
+                          </AspectRatio>
+                        </div>
+                      </DialogTrigger>
+                      <DialogContent className="max-w-3xl p-0 overflow-hidden">
+                        <AspectRatio ratio={16 / 9}>
+                          <img src={m.src} alt={m.title} className="h-full w-full object-cover" />
+                        </AspectRatio>
+                        <div className="p-4 flex items-center justify-between">
+                          <div className="text-sm font-medium">{m.title}</div>
+                          <div className="flex gap-2">
+                            {m.type === "video" ? (
+                              <Badge className="bg-secondary text-secondary-foreground">Video</Badge>
+                            ) : (
+                              <Badge className="bg-primary text-primary-foreground">Photo</Badge>
+                            )}
+                          </div>
+                        </div>
+                      </DialogContent>
+                    </Dialog>
+                  </Card>
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+            <CarouselPrevious />
+            <CarouselNext />
+          </Carousel>
+        )}
+
+        {/* Grid gallery */}
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          {filtered.map((m) => (
+            <Card key={m.id} className="overflow-hidden bg-card/80 backdrop-blur-sm">
+              <Dialog>
+                <DialogTrigger asChild>
+                  <div className="cursor-pointer">
+                    <AspectRatio ratio={1}>
+                      <img src={m.src} alt={m.title} className="h-full w-full object-cover" />
+                    </AspectRatio>
+                  </div>
+                </DialogTrigger>
+                <DialogContent className="max-w-3xl p-0 overflow-hidden">
+                  <AspectRatio ratio={16 / 9}>
+                    <img src={m.src} alt={m.title} className="h-full w-full object-cover" />
+                  </AspectRatio>
+                  <div className="p-4 flex items-center justify-between">
+                    <div className="text-sm font-medium">{m.title}</div>
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      {m.type === "video" ? (
+                        <><Video className="w-4 h-4" /> Video</>
+                      ) : (
+                        <><ImageIcon className="w-4 h-4" /> Photo</>
+                      )}
+                    </div>
+                  </div>
+                </DialogContent>
+              </Dialog>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Media;
+

--- a/src/pages/app/Wallet.tsx
+++ b/src/pages/app/Wallet.tsx
@@ -2,6 +2,8 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import AppHeader from "@/components/AppHeader";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext } from "@/components/ui/carousel";
 import { 
   Send, 
   ArrowDownLeft, 
@@ -20,6 +22,11 @@ import { useState } from "react";
 
 const Wallet = () => {
   const [showBalance, setShowBalance] = useState(true);
+  const cards = [
+    { brand: "KasiLink Debit", last4: "4821", balance: 1250.5, gradient: "from-community via-primary to-secondary" },
+    { brand: "Savings", last4: "9013", balance: 5600, gradient: "from-primary via-secondary to-community" },
+    { brand: "Stokvel Pool", last4: "2745", balance: 22500, gradient: "from-secondary via-primary to-community" }
+  ];
 
   const quickActions = [
     { icon: Send, label: "Send", color: "primary" },
@@ -113,6 +120,32 @@ const Wallet = () => {
       <AppHeader title="Wallet" />
       
       <div className="p-4 space-y-6">
+        {/* Cards Carousel */}
+        <Carousel className="w-full">
+          <CarouselContent>
+            {cards.map((card, idx) => (
+              <CarouselItem key={idx} className="md:basis-2/3 lg:basis-1/2">
+                <Card className={`p-5 bg-gradient-to-br ${card.gradient} text-white border-white/20 shadow-xl`}>
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <div className="text-xs opacity-70">Current Balance</div>
+                      <div className="text-2xl font-bold">
+                        {showBalance ? `R${card.balance.toLocaleString()}` : "R****.**"}
+                      </div>
+                    </div>
+                    <CreditCard className="w-8 h-8 opacity-80" />
+                  </div>
+                  <div className="flex items-center justify-between mt-6">
+                    <div className="text-sm">{card.brand}</div>
+                    <div className="text-sm tracking-widest">•••• {card.last4}</div>
+                  </div>
+                </Card>
+              </CarouselItem>
+            ))}
+          </CarouselContent>
+          <CarouselPrevious />
+          <CarouselNext />
+        </Carousel>
         {/* Balance Card */}
         <Card className="p-6 bg-gradient-to-r from-community/20 via-primary/10 to-secondary/20 border-community/30">
           <div className="flex items-center justify-between mb-4">
@@ -156,96 +189,170 @@ const Wallet = () => {
           </div>
         </Card>
 
-        {/* Stokvels Section */}
-        <div>
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-foreground">My Stokvels</h3>
-            <Button variant="outline" size="sm">
-              <Plus className="w-4 h-4 mr-2" />
-              Join Group
-            </Button>
-          </div>
-          
-          <div className="space-y-3">
-            {stokvels.map((stokvel, index) => (
-              <Card key={index} className="p-4 bg-card/80 backdrop-blur-sm">
-                <div className="flex items-start justify-between mb-3">
-                  <div>
-                    <h4 className="font-semibold text-foreground">{stokvel.name}</h4>
-                    <p className="text-sm text-muted-foreground">{stokvel.members} members</p>
-                  </div>
-                  <Badge className={getStatusColor(stokvel.status)}>
-                    {stokvel.status}
-                  </Badge>
-                </div>
-                
-                <div className="grid grid-cols-3 gap-4 text-center">
-                  <div>
-                    <div className="text-lg font-bold text-community">
-                      R{stokvel.balance.toLocaleString()}
+        {/* Segmented Tabs */}
+        <Tabs defaultValue="overview" className="w-full">
+          <TabsList className="grid grid-cols-3 w-full">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="stokvels">Stokvels</TabsTrigger>
+            <TabsTrigger value="history">History</TabsTrigger>
+          </TabsList>
+          <TabsContent value="overview" className="space-y-6">
+            {/* Stokvels Section */}
+            <div>
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-semibold text-foreground">My Stokvels</h3>
+                <Button variant="outline" size="sm">
+                  <Plus className="w-4 h-4 mr-2" />
+                  Join Group
+                </Button>
+              </div>
+              <div className="space-y-3">
+                {stokvels.map((stokvel, index) => (
+                  <Card key={index} className="p-4 bg-card/80 backdrop-blur-sm">
+                    <div className="flex items-start justify-between mb-3">
+                      <div>
+                        <h4 className="font-semibold text-foreground">{stokvel.name}</h4>
+                        <p className="text-sm text-muted-foreground">{stokvel.members} members</p>
+                      </div>
+                      <Badge className={getStatusColor(stokvel.status)}>
+                        {stokvel.status}
+                      </Badge>
                     </div>
-                    <div className="text-xs text-muted-foreground">Group Balance</div>
-                  </div>
-                  <div>
-                    <div className="text-lg font-bold text-primary">R{stokvel.contribution}</div>
-                    <div className="text-xs text-muted-foreground">My Contribution</div>
-                  </div>
-                  <div>
-                    <div className="text-lg font-bold text-secondary">{stokvel.nextPayout}</div>
-                    <div className="text-xs text-muted-foreground">Next Payout</div>
-                  </div>
-                </div>
-              </Card>
-            ))}
-          </div>
-        </div>
-
-        {/* Transaction History */}
-        <div>
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-foreground">Recent Transactions</h3>
-            <Button variant="ghost" size="sm">
-              <History className="w-4 h-4 mr-2" />
-              View All
-            </Button>
-          </div>
-          
-          <div className="space-y-2">
-            {transactions.map((transaction, index) => {
-              const TransactionIcon = getTransactionIcon(transaction.type);
-              const isReceived = transaction.type === 'received';
-              
-              return (
-                <Card key={index} className="p-4 bg-card/80 backdrop-blur-sm">
-                  <div className="flex items-center gap-3">
-                    <div className={`w-10 h-10 rounded-full flex items-center justify-center ${
-                      isReceived ? 'bg-community/20 text-community' : 'bg-primary/20 text-primary'
-                    }`}>
-                      <TransactionIcon className="w-5 h-5" />
+                    <div className="grid grid-cols-3 gap-4 text-center">
+                      <div>
+                        <div className="text-lg font-bold text-community">
+                          R{stokvel.balance.toLocaleString()}
+                        </div>
+                        <div className="text-xs text-muted-foreground">Group Balance</div>
+                      </div>
+                      <div>
+                        <div className="text-lg font-bold text-primary">R{stokvel.contribution}</div>
+                        <div className="text-xs text-muted-foreground">My Contribution</div>
+                      </div>
+                      <div>
+                        <div className="text-lg font-bold text-secondary">{stokvel.nextPayout}</div>
+                        <div className="text-xs text-muted-foreground">Next Payout</div>
+                      </div>
                     </div>
-                    
-                    <div className="flex-1">
-                      <div className="flex items-center justify-between mb-1">
-                        <h4 className="font-semibold text-foreground">
-                          {isReceived ? transaction.from : transaction.to}
-                        </h4>
-                        <span className={`font-bold ${
-                          isReceived ? 'text-community' : 'text-foreground'
+                  </Card>
+                ))}
+              </div>
+            </div>
+            {/* Transaction History */}
+            <div>
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-semibold text-foreground">Recent Transactions</h3>
+                <Button variant="ghost" size="sm">
+                  <History className="w-4 h-4 mr-2" />
+                  View All
+                </Button>
+              </div>
+              <div className="space-y-2">
+                {transactions.map((transaction, index) => {
+                  const TransactionIcon = getTransactionIcon(transaction.type);
+                  const isReceived = transaction.type === 'received';
+                  return (
+                    <Card key={index} className="p-4 bg-card/80 backdrop-blur-sm">
+                      <div className="flex items-center gap-3">
+                        <div className={`w-10 h-10 rounded-full flex items-center justify-center ${
+                          isReceived ? 'bg-community/20 text-community' : 'bg-primary/20 text-primary'
                         }`}>
-                          {isReceived ? '+' : '-'}R{transaction.amount}
-                        </span>
+                          <TransactionIcon className="w-5 h-5" />
+                        </div>
+                        <div className="flex-1">
+                          <div className="flex items-center justify-between mb-1">
+                            <h4 className="font-semibold text-foreground">
+                              {isReceived ? transaction.from : transaction.to}
+                            </h4>
+                            <span className={`font-bold ${
+                              isReceived ? 'text-community' : 'text-foreground'
+                            }`}>
+                              {isReceived ? '+' : '-'}R{transaction.amount}
+                            </span>
+                          </div>
+                          <div className="flex items-center justify-between">
+                            <p className="text-sm text-muted-foreground">{transaction.description}</p>
+                            <span className="text-xs text-muted-foreground">{transaction.time}</span>
+                          </div>
+                        </div>
                       </div>
-                      <div className="flex items-center justify-between">
-                        <p className="text-sm text-muted-foreground">{transaction.description}</p>
-                        <span className="text-xs text-muted-foreground">{transaction.time}</span>
+                    </Card>
+                  );
+                })}
+              </div>
+            </div>
+          </TabsContent>
+          <TabsContent value="stokvels">
+            {/* Stokvels only */}
+            <div className="space-y-3">
+              {stokvels.map((stokvel, index) => (
+                <Card key={index} className="p-4 bg-card/80 backdrop-blur-sm">
+                  <div className="flex items-start justify-between mb-3">
+                    <div>
+                      <h4 className="font-semibold text-foreground">{stokvel.name}</h4>
+                      <p className="text-sm text-muted-foreground">{stokvel.members} members</p>
+                    </div>
+                    <Badge className={getStatusColor(stokvel.status)}>
+                      {stokvel.status}
+                    </Badge>
+                  </div>
+                  <div className="grid grid-cols-3 gap-4 text-center">
+                    <div>
+                      <div className="text-lg font-bold text-community">
+                        R{stokvel.balance.toLocaleString()}
                       </div>
+                      <div className="text-xs text-muted-foreground">Group Balance</div>
+                    </div>
+                    <div>
+                      <div className="text-lg font-bold text-primary">R{stokvel.contribution}</div>
+                      <div className="text-xs text-muted-foreground">My Contribution</div>
+                    </div>
+                    <div>
+                      <div className="text-lg font-bold text-secondary">{stokvel.nextPayout}</div>
+                      <div className="text-xs text-muted-foreground">Next Payout</div>
                     </div>
                   </div>
                 </Card>
-              );
-            })}
-          </div>
-        </div>
+              ))}
+            </div>
+          </TabsContent>
+          <TabsContent value="history">
+            {/* Transactions only */}
+            <div className="space-y-2">
+              {transactions.map((transaction, index) => {
+                const TransactionIcon = getTransactionIcon(transaction.type);
+                const isReceived = transaction.type === 'received';
+                return (
+                  <Card key={index} className="p-4 bg-card/80 backdrop-blur-sm">
+                    <div className="flex items-center gap-3">
+                      <div className={`w-10 h-10 rounded-full flex items-center justify-center ${
+                        isReceived ? 'bg-community/20 text-community' : 'bg-primary/20 text-primary'
+                      }`}>
+                        <TransactionIcon className="w-5 h-5" />
+                      </div>
+                      <div className="flex-1">
+                        <div className="flex items-center justify-between mb-1">
+                          <h4 className="font-semibold text-foreground">
+                            {isReceived ? transaction.from : transaction.to}
+                          </h4>
+                          <span className={`font-bold ${
+                            isReceived ? 'text-community' : 'text-foreground'
+                          }`}>
+                            {isReceived ? '+' : '-'}R{transaction.amount}
+                          </span>
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <p className="text-sm text-muted-foreground">{transaction.description}</p>
+                          <span className="text-xs text-muted-foreground">{transaction.time}</span>
+                        </div>
+                      </div>
+                    </div>
+                  </Card>
+                );
+              })}
+            </div>
+          </TabsContent>
+        </Tabs>
       </div>
     </div>
   );


### PR DESCRIPTION
Add Groups and Media pages, update home quick actions, and enhance Wallet UI with an iOS-style card carousel and segmented tabs to implement requested iOS features.

---
<a href="https://cursor.com/background-agent?bcId=bc-67c5bfa8-bcf0-446c-9d8f-a75df27eb90d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-67c5bfa8-bcf0-446c-9d8f-a75df27eb90d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

