### PR TITLE
Android group chat and media integration

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
 	implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4")
 	implementation("androidx.datastore:datastore-preferences:1.1.1")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+	implementation("io.coil-kt:coil-compose:2.6.0")
 
 	debugImplementation("androidx.compose.ui:ui-tooling")
 	debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+	<uses-permission android:name="android.permission.INTERNET" />
 	<application
 		android:allowBackup="true"
 		android:icon="@mipmap/ic_launcher"

--- a/android/app/src/main/java/com/example/androidcore/MainActivity.kt
+++ b/android/app/src/main/java/com/example/androidcore/MainActivity.kt
@@ -36,6 +36,7 @@ sealed class Screen(val route: String) {
 	data object ChatDetail : Screen("chat/{chatId}") {
 		fun route(chatId: String) = "chat/$chatId"
 	}
+	data object CreateGroup : Screen("create_group")
 }
 
 @Composable
@@ -75,13 +76,30 @@ fun AppNavHost(navController: NavHostController, authRepository: AuthRepository,
 			})
 		}
 		composable(Screen.Chats.route) {
-			ChatsScreen(chatRepository = chatRepository, onOpenChat = { chatId ->
-				navController.navigate(Screen.ChatDetail.route(chatId))
-			})
+			ChatsScreen(
+				chatRepository = chatRepository,
+				onOpenChat = { chatId ->
+					navController.navigate(Screen.ChatDetail.route(chatId))
+				},
+				onOpenCreateGroup = {
+					navController.navigate(Screen.CreateGroup.route)
+				}
+			)
 		}
 		composable(Screen.ChatDetail.route) {
 			val chatId = it.arguments?.getString("chatId") ?: ""
 			ChatDetailScreen(chatId = chatId, chatRepository = chatRepository, onBack = { navController.popBackStack() })
+		}
+		composable(Screen.CreateGroup.route) {
+			CreateGroupScreen(
+				chatRepository = chatRepository,
+				onCreated = { newChatId ->
+					navController.navigate(Screen.ChatDetail.route(newChatId)) {
+						popUpTo(Screen.Chats.route)
+					}
+				},
+				onCancel = { navController.popBackStack() }
+			)
 		}
 	}
 }


### PR DESCRIPTION
Implement group chat creation with a 256-member limit, add a media picker stub, and enable media message display in the Android app.

---
<a href="https://cursor.com/background-agent?bcId=bc-04f35f05-64e9-4119-9d97-c4dce2784a7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04f35f05-64e9-4119-9d97-c4dce2784a7a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

