### PR TITLE
Setup iOS group chat and media upload

### DIFF
--- a/ios/Sources/App/ChatApp.swift
+++ b/ios/Sources/App/ChatApp.swift
@@ -3,10 +3,12 @@ import SwiftUI
 final class ServiceContainer: ObservableObject {
     let authService: AuthService
     let chatService: ChatService
+    let mediaUploadService: MediaUploadService
 
-    init(authService: AuthService, chatService: ChatService) {
+    init(authService: AuthService, chatService: ChatService, mediaUploadService: MediaUploadService) {
         self.authService = authService
         self.chatService = chatService
+        self.mediaUploadService = mediaUploadService
     }
 }
 
@@ -18,7 +20,8 @@ struct ChatApp: App {
     init() {
         let services = ServiceContainer(
             authService: MockAuthService(),
-            chatService: MockChatService()
+            chatService: MockChatService(),
+            mediaUploadService: MockMediaUploadService()
         )
         _services = StateObject(wrappedValue: services)
         _authViewModel = StateObject(wrappedValue: AuthViewModel(service: services.authService))

--- a/ios/Sources/Services/MediaUploadService.swift
+++ b/ios/Sources/Services/MediaUploadService.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+public struct MediaUploadInfo {
+    public let uploadURL: URL
+    public let mediaId: String
+
+    public init(uploadURL: URL, mediaId: String) {
+        self.uploadURL = uploadURL
+        self.mediaId = mediaId
+    }
+}
+
+public protocol MediaUploadService {
+    func requestUploadURL(filename: String, contentType: String) async throws -> MediaUploadInfo
+    func confirmUpload(mediaId: String) async throws
+}
+
+public enum MediaUploadError: Error {
+    case invalidURL
+}
+
+public final class MockMediaUploadService: MediaUploadService {
+    public init() {}
+
+    public func requestUploadURL(filename: String, contentType: String) async throws -> MediaUploadInfo {
+        // Stub a pre-signed upload URL
+        let id = UUID().uuidString
+        guard let url = URL(string: "https://example.com/upload/\(id)?filename=\(filename)") else {
+            throw MediaUploadError.invalidURL
+        }
+        return MediaUploadInfo(uploadURL: url, mediaId: id)
+    }
+
+    public func confirmUpload(mediaId: String) async throws {
+        // No-op in mock
+    }
+}
+

--- a/ios/Sources/ViewModels/ChatThreadViewModel.swift
+++ b/ios/Sources/ViewModels/ChatThreadViewModel.swift
@@ -26,5 +26,11 @@ final class ChatThreadViewModel: ObservableObject {
         composerText = ""
         try? await service.sendMessage(threadId: threadId, text: text, from: user)
     }
+
+    func sendMediaPlaceholder(filename: String, mediaId: String, from user: AppUser) async {
+        let shortId = String(mediaId.prefix(8))
+        let text = "Sent media: \(filename) [\(shortId)]"
+        try? await service.sendMessage(threadId: threadId, text: text, from: user)
+    }
 }
 

--- a/ios/Sources/Views/ChatThreadView.swift
+++ b/ios/Sources/Views/ChatThreadView.swift
@@ -6,6 +6,8 @@ struct ChatThreadView: View {
     let service: ChatService
     let threadId: String
     @StateObject private var viewModel: ChatThreadViewModel
+    @State private var isShowingMediaSheet: Bool = false
+    @State private var isUploading: Bool = false
 
     init(service: ChatService, threadId: String) {
         self.service = service
@@ -34,6 +36,14 @@ struct ChatThreadView: View {
                 .listStyle(.plain)
             }
             HStack(alignment: .bottom, spacing: 8) {
+                Button {
+                    isShowingMediaSheet = true
+                } label: {
+                    Image(systemName: "paperclip")
+                        .padding(8)
+                }
+                .buttonStyle(.bordered)
+                .disabled(isUploading)
                 TextField("Message", text: $viewModel.composerText, axis: .vertical)
                     .textFieldStyle(.roundedBorder)
                 Button {
@@ -50,6 +60,54 @@ struct ChatThreadView: View {
             .background(.ultraThinMaterial)
         }
         .navigationTitle("Thread")
+        .sheet(isPresented: $isShowingMediaSheet) {
+            VStack(spacing: 16) {
+                Text("Media Picker (stub)").font(.headline)
+                if isUploading {
+                    ProgressView("Uploading...")
+                }
+                Button {
+                    uploadStub(filename: "photo.jpg", contentType: "image/jpeg")
+                } label: {
+                    Label("Pick Photo (stub)", systemImage: "photo")
+                }
+                .disabled(isUploading)
+                Button {
+                    uploadStub(filename: "video.mov", contentType: "video/quicktime")
+                } label: {
+                    Label("Pick Video (stub)", systemImage: "video")
+                }
+                .disabled(isUploading)
+                Button("Cancel") {
+                    isShowingMediaSheet = false
+                }
+                .keyboardShortcut(.cancelAction)
+                .disabled(isUploading)
+                Spacer()
+            }
+            .padding()
+            .presentationDetents([.medium])
+        }
+    }
+}
+
+private extension ChatThreadView {
+    func uploadStub(filename: String, contentType: String) {
+        guard let user = authViewModel.currentUser else { return }
+        isUploading = true
+        Task {
+            do {
+                let info = try await services.mediaUploadService.requestUploadURL(filename: filename, contentType: contentType)
+                // Simulate an upload delay
+                try? await Task.sleep(nanoseconds: 300_000_000)
+                try await services.mediaUploadService.confirmUpload(mediaId: info.mediaId)
+                await viewModel.sendMediaPlaceholder(filename: filename, mediaId: info.mediaId, from: user)
+            } catch {
+                // Ignore errors in stub
+            }
+            isUploading = false
+            isShowingMediaSheet = false
+        }
     }
 }
 

--- a/ios/Sources/Views/GroupsView.swift
+++ b/ios/Sources/Views/GroupsView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct GroupsView: View {
+    @EnvironmentObject private var services: ServiceContainer
+    @State private var isShowingCreateSheet: Bool = false
+    @State private var provisionalMemberCount: Int = 1
+
+    private let maxMembers: Int = 256
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Groups").font(.title2)
+            Text("Placeholder for group chats").foregroundColor(.secondary)
+            Button {
+                isShowingCreateSheet = true
+            } label: {
+                Label("Create Group", systemImage: "person.3.fill")
+            }
+            .buttonStyle(.borderedProminent)
+            Spacer()
+        }
+        .padding()
+        .navigationTitle("Groups")
+        .sheet(isPresented: $isShowingCreateSheet) {
+            VStack(spacing: 16) {
+                Text("New Group (stub)").font(.headline)
+                Text("Select up to \(maxMembers) members")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                Stepper(value: $provisionalMemberCount, in: 1...maxMembers) {
+                    Text("Members: \(provisionalMemberCount)/\(maxMembers)")
+                }
+                Button {
+                    isShowingCreateSheet = false
+                } label: {
+                    Text("Create Group (stub)")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(provisionalMemberCount == 0 || provisionalMemberCount > maxMembers)
+                Button("Cancel") {
+                    isShowingCreateSheet = false
+                }
+                .keyboardShortcut(.cancelAction)
+                Spacer()
+            }
+            .padding()
+            .presentationDetents([.medium])
+        }
+    }
+}
+

--- a/ios/Sources/Views/MainTabView.swift
+++ b/ios/Sources/Views/MainTabView.swift
@@ -14,6 +14,13 @@ struct MainTabView: View {
             }
 
             NavigationStack {
+                GroupsView()
+            }
+            .tabItem {
+                Label("Groups", systemImage: "person.3")
+            }
+
+            NavigationStack {
                 VStack(spacing: 16) {
                     Text("Settings")
                         .font(.title2)


### PR DESCRIPTION
Add a Groups placeholder tab with a 256-member limit stub and integrate a media picker stub with upload service.

---
<a href="https://cursor.com/background-agent?bcId=bc-81b9947d-411f-4bc7-a46b-df86cddb03eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81b9947d-411f-4bc7-a46b-df86cddb03eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

