### PR TITLE
Setup iOS group chat and media upload

### DIFF
--- a/ios/Resources/Info.plist
+++ b/ios/Resources/Info.plist
@@ -34,5 +34,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This app needs access to your photo library to share photos in chat.</string>
 </dict>
 </plist>

--- a/ios/Sources/ViewModels/ChatThreadViewModel.swift
+++ b/ios/Sources/ViewModels/ChatThreadViewModel.swift
@@ -1,10 +1,12 @@
 import Foundation
 import Combine
+import PhotosUI
 
 @MainActor
 final class ChatThreadViewModel: ObservableObject {
     @Published private(set) var messages: [ChatMessage] = []
     @Published var composerText: String = ""
+    @Published var selectedItem: PhotosPickerItem?
 
     private let service: ChatService
     private let threadId: String
@@ -25,6 +27,19 @@ final class ChatThreadViewModel: ObservableObject {
         guard !text.isEmpty else { return }
         composerText = ""
         try? await service.sendMessage(threadId: threadId, text: text, from: user)
+    }
+
+    func handleSelectedPhoto(as user: AppUser) async {
+        guard selectedItem != nil else { return }
+        // For Day 1 stub: skip real data extraction and upload placeholder content
+        let placeholderData = Data()
+        do {
+            let url = try await service.uploadMedia(data: placeholderData, fileName: "photo.jpg", mimeType: "image/jpeg")
+            try? await service.sendMessage(threadId: threadId, text: "Shared media: \(url.absoluteString)", from: user)
+        } catch {
+            // Optionally, one could emit a system message or error state
+        }
+        selectedItem = nil
     }
 }
 

--- a/ios/Sources/Views/ChatListView.swift
+++ b/ios/Sources/Views/ChatListView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ChatListView: View {
     let service: ChatService
     @StateObject private var viewModel: ChatListViewModel
+    @State private var isPresentingNewGroup: Bool = false
 
     init(service: ChatService) {
         self.service = service
@@ -10,29 +11,43 @@ struct ChatListView: View {
     }
 
     var body: some View {
-        List(viewModel.threads) { thread in
-            NavigationLink(value: thread.id) {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text(thread.title).font(.headline)
-                        if thread.unreadCount > 0 {
-                            Spacer()
-                            Text("\(thread.unreadCount)")
-                                .font(.caption2)
-                                .padding(4)
-                                .background(Color.blue.opacity(0.15))
-                                .clipShape(Capsule())
+        List {
+            Section {
+                Button {
+                    isPresentingNewGroup = true
+                } label: {
+                    Label("New Group", systemImage: "person.3.fill")
+                }
+            }
+            Section {
+                ForEach(viewModel.threads) { thread in
+                    NavigationLink(value: thread.id) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text(thread.title).font(.headline)
+                                if thread.unreadCount > 0 {
+                                    Spacer()
+                                    Text("\(thread.unreadCount)")
+                                        .font(.caption2)
+                                        .padding(4)
+                                        .background(Color.blue.opacity(0.15))
+                                        .clipShape(Capsule())
+                                }
+                            }
+                            Text(thread.lastMessagePreview)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
                         }
                     }
-                    Text(thread.lastMessagePreview)
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
                 }
             }
         }
         .navigationTitle("Chats")
         .navigationDestination(for: String.self) { threadId in
             ChatThreadView(service: service, threadId: threadId)
+        }
+        .sheet(isPresented: $isPresentingNewGroup) {
+            GroupSetupView(service: service, isPresented: $isPresentingNewGroup)
         }
     }
 }

--- a/ios/Sources/Views/ChatThreadView.swift
+++ b/ios/Sources/Views/ChatThreadView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PhotosUI
 
 struct ChatThreadView: View {
     @EnvironmentObject private var services: ServiceContainer
@@ -34,6 +35,10 @@ struct ChatThreadView: View {
                 .listStyle(.plain)
             }
             HStack(alignment: .bottom, spacing: 8) {
+                PhotosPicker(selection: $viewModel.selectedItem, matching: .images, photoLibrary: .shared()) {
+                    Image(systemName: "photo.fill.on.rectangle.fill")
+                        .padding(8)
+                }
                 TextField("Message", text: $viewModel.composerText, axis: .vertical)
                     .textFieldStyle(.roundedBorder)
                 Button {
@@ -50,6 +55,11 @@ struct ChatThreadView: View {
             .background(.ultraThinMaterial)
         }
         .navigationTitle("Thread")
+        .task(id: viewModel.selectedItem) {
+            if let user = authViewModel.currentUser {
+                await viewModel.handleSelectedPhoto(as: user)
+            }
+        }
     }
 }
 

--- a/ios/Sources/Views/GroupSetupView.swift
+++ b/ios/Sources/Views/GroupSetupView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+struct GroupSetupView: View {
+    let service: ChatService
+    @Binding var isPresented: Bool
+
+    @State private var groupTitle: String = ""
+    @State private var memberNames: String = ""
+    @State private var isCreating: Bool = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section(header: Text("Group Name")) {
+                    TextField("Enter group title", text: $groupTitle)
+                }
+                Section(header: Text("Members (comma-separated)"), footer: Text("Up to 256 members supported").font(.footnote)) {
+                    TextField("e.g. Alex, Sam, Taylor", text: $memberNames)
+                }
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .foregroundColor(.red)
+                    }
+                }
+            }
+            .navigationTitle("New Group")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { isPresented = false }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(isCreating ? "Creating…" : "Create") {
+                        Task { await createGroup() }
+                    }
+                    .disabled(isCreating)
+                }
+            }
+        }
+    }
+
+    private func createGroup() async {
+        guard !isCreating else { return }
+        isCreating = true
+        defer { isCreating = false }
+
+        let names = memberNames
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        // Build mock users list; include a placeholder current user called "You" if not present
+        var users: [AppUser] = names.enumerated().map { index, name in
+            AppUser(id: "u_\(index)_\(name.lowercased())", displayName: name)
+        }
+        if !users.contains(where: { $0.displayName.lowercased() == "you" }) {
+            users.insert(AppUser(id: "u_demo", displayName: "You"), at: 0)
+        }
+
+        do {
+            _ = try await service.createGroupThread(title: groupTitle, participants: Array(users.prefix(256)))
+            isPresented = false
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+


### PR DESCRIPTION
Add group chat placeholder UI, media picker stub, and mock service integration to enable basic group creation and media sharing.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e64e239-159c-45f4-932a-a0424ed56b11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e64e239-159c-45f4-932a-a0424ed56b11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

