### PR TITLE
Setup ios core with group chat and notifications

### DIFF
--- a/ios/App/App.swift
+++ b/ios/App/App.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+@main
+struct Agent3ChatApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    private let container = ServiceContainer()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(container.sessionManager)
+                .environmentObject(container.otpLoginViewModel)
+                .environmentObject(container.conversationsViewModel)
+        }
+    }
+}
+
+struct RootView: View {
+    @EnvironmentObject var sessionManager: SessionManager
+    @EnvironmentObject var conversationsViewModel: ConversationsViewModel
+
+    var body: some View {
+        Group {
+            if sessionManager.isAuthenticated {
+                ConversationsListView()
+                    .environmentObject(conversationsViewModel)
+            } else {
+                OTPLoginView()
+            }
+        }
+    }
+}

--- a/ios/App/AppDelegate.swift
+++ b/ios/App/AppDelegate.swift
@@ -1,0 +1,23 @@
+import UIKit
+import UserNotifications
+
+final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        PushService.shared.requestAuthorizationAndRegister()
+        return true
+    }
+
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        PushService.shared.didRegisterForRemoteNotifications(deviceToken: deviceToken)
+    }
+
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        PushService.shared.didFailToRegisterForRemoteNotifications(error: error)
+    }
+
+    // Foreground notification handling
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .list, .sound])
+    }
+}

--- a/ios/App/ServiceContainer.swift
+++ b/ios/App/ServiceContainer.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+final class ServiceContainer {
+    let authService: OTPAuthServiceProtocol
+    let encryptionService: EncryptionServiceProtocol
+    let messagingService: MessagingServiceProtocol
+    let pushService: PushService
+
+    let sessionManager: SessionManager
+    let otpLoginViewModel: OTPLoginViewModel
+    let conversationsViewModel: ConversationsViewModel
+
+    init() {
+        let encryptionService: EncryptionServiceProtocol = LibSignalEncryptionService()
+        let authService: OTPAuthServiceProtocol = MockOTPAuthService()
+        let messagingService: MessagingServiceProtocol = InMemoryMessagingService(encryptionService: encryptionService)
+        let pushService = PushService.shared
+
+        self.encryptionService = encryptionService
+        self.authService = authService
+        self.messagingService = messagingService
+        self.pushService = pushService
+
+        self.sessionManager = SessionManager()
+        self.otpLoginViewModel = OTPLoginViewModel(authService: authService, sessionManager: sessionManager)
+        self.conversationsViewModel = ConversationsViewModel(messagingService: messagingService)
+    }
+}
+

--- a/ios/Config/App.entitlements
+++ b/ios/Config/App.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>aps-environment</key>
+    <string>development</string>
+</dict>
+</plist>

--- a/ios/Config/Info.plist
+++ b/ios/Config/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIMainStoryboardFile</key>
+    <string></string>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+    </dict>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+    </array>
+    <key>UIUserInterfaceStyle</key>
+    <string>Light</string>
+    <key>UIBackgroundModes</key>
+    <array>
+        <string>remote-notification</string>
+    </array>
+</dict>
+</plist>

--- a/ios/Models/Models.swift
+++ b/ios/Models/Models.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+struct User: Identifiable, Hashable, Codable {
+    let id: String
+    var displayName: String
+    var phoneNumberE164: String
+}
+
+struct Message: Identifiable, Hashable, Codable {
+    let id: String
+    let conversationId: String
+    let senderId: String
+    var sentAt: Date
+    var isEncrypted: Bool
+    var ciphertext: String
+    var plaintext: String? // Derived after decryption
+}
+
+struct Conversation: Identifiable, Hashable, Codable {
+    let id: String
+    var title: String
+    var isGroup: Bool
+    var participantIds: [String]
+    var lastMessagePreview: String?
+    var updatedAt: Date
+}
+

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,3 +1,19 @@
+Agent3Chat iOS
+
+Requirements
+- Xcode 15+
+- XcodeGen (`brew install xcodegen`)
+
+Generate project
+```bash
+xcodegen generate --spec project.yml
+```
+
+Open `Agent3Chat.xcodeproj` and run on iOS 16+.
+
+Notes
+- Push requires a real device and proper provisioning. `aps-environment` is set to development in `Config/App.entitlements`.
+- `libsignal-client` is added via SPM in `project.yml`. The current `LibSignalEncryptionService` is a placeholder until full integration.
 # ChatApp iOS
 
 SwiftUI iOS app shell with auth and chat UI, generated via XcodeGen.

--- a/ios/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,7 @@
+{
+  "images" : [
+    { "idiom" : "iphone", "size" : "60x60", "scale" : "2x" },
+    { "idiom" : "iphone", "size" : "60x60", "scale" : "3x" }
+  ],
+  "info" : { "version" : 1, "author" : "xcode" }
+}

--- a/ios/Services/EncryptionService.swift
+++ b/ios/Services/EncryptionService.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+protocol EncryptionServiceProtocol {
+    func encrypt(plaintext: String, forConversation conversationId: String, senderId: String) throws -> String
+    func decrypt(ciphertext: String, forConversation conversationId: String, recipientId: String) throws -> String
+}
+
+enum EncryptionError: Error {
+    case notAvailable
+}
+
+final class LibSignalEncryptionService: EncryptionServiceProtocol {
+    func encrypt(plaintext: String, forConversation conversationId: String, senderId: String) throws -> String {
+        // Placeholder until libsignal-client wiring is implemented
+        return "enc::" + Data(plaintext.utf8).base64EncodedString()
+    }
+
+    func decrypt(ciphertext: String, forConversation conversationId: String, recipientId: String) throws -> String {
+        // Placeholder until libsignal-client wiring is implemented
+        guard ciphertext.hasPrefix("enc::") else { return ciphertext }
+        let base64 = String(ciphertext.dropFirst(5))
+        guard let data = Data(base64Encoded: base64), let str = String(data: data, encoding: .utf8) else {
+            return ciphertext
+        }
+        return str
+    }
+}
+

--- a/ios/Services/MessagingService.swift
+++ b/ios/Services/MessagingService.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+protocol MessagingServiceProtocol {
+    func loadConversations() async throws -> [Conversation]
+    func createGroup(title: String, participantIds: [String]) async throws -> Conversation
+    func sendMessage(conversationId: String, senderId: String, text: String) async throws -> Message
+    func loadMessages(conversationId: String) async throws -> [Message]
+}
+
+final class InMemoryMessagingService: MessagingServiceProtocol {
+    private let encryptionService: EncryptionServiceProtocol
+    private var conversationsById: [String: Conversation] = [:]
+    private var messagesByConversationId: [String: [Message]] = [:]
+
+    init(encryptionService: EncryptionServiceProtocol) {
+        self.encryptionService = encryptionService
+        seed()
+    }
+
+    private func seed() {
+        let c1 = Conversation(id: UUID().uuidString, title: "General", isGroup: true, participantIds: ["me", "u1", "u2"], lastMessagePreview: "Welcome to Agent3", updatedAt: Date())
+        conversationsById[c1.id] = c1
+        messagesByConversationId[c1.id] = []
+    }
+
+    func loadConversations() async throws -> [Conversation] {
+        try await Task.sleep(nanoseconds: 200_000_000)
+        return conversationsById.values.sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    func createGroup(title: String, participantIds: [String]) async throws -> Conversation {
+        let conv = Conversation(id: UUID().uuidString, title: title, isGroup: true, participantIds: participantIds, lastMessagePreview: nil, updatedAt: Date())
+        conversationsById[conv.id] = conv
+        messagesByConversationId[conv.id] = []
+        return conv
+    }
+
+    func sendMessage(conversationId: String, senderId: String, text: String) async throws -> Message {
+        let ciphertext = try encryptionService.encrypt(plaintext: text, forConversation: conversationId, senderId: senderId)
+        let message = Message(id: UUID().uuidString, conversationId: conversationId, senderId: senderId, sentAt: Date(), isEncrypted: true, ciphertext: ciphertext, plaintext: nil)
+        messagesByConversationId[conversationId, default: []].append(message)
+        if var conv = conversationsById[conversationId] {
+            conv.lastMessagePreview = text
+            conv.updatedAt = Date()
+            conversationsById[conversationId] = conv
+        }
+        return message
+    }
+
+    func loadMessages(conversationId: String) async throws -> [Message] {
+        try await Task.sleep(nanoseconds: 150_000_000)
+        let decrypted: [Message] = messagesByConversationId[conversationId, default: []].map { msg in
+            var m = msg
+            if let text = try? encryptionService.decrypt(ciphertext: msg.ciphertext, forConversation: conversationId, recipientId: "me") {
+                m.plaintext = text
+            }
+            return m
+        }
+        return decrypted.sorted { $0.sentAt < $1.sentAt }
+    }
+}
+

--- a/ios/Services/OTPAuthService.swift
+++ b/ios/Services/OTPAuthService.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+protocol OTPAuthServiceProtocol {
+    func requestOTP(phoneNumberE164: String) async throws
+    func verifyOTP(phoneNumberE164: String, code: String) async throws -> User
+}
+
+enum AuthError: Error, LocalizedError {
+    case invalidCode
+    case network
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidCode: return "Invalid verification code"
+        case .network: return "Network error"
+        }
+    }
+}
+
+final class MockOTPAuthService: OTPAuthServiceProtocol {
+    func requestOTP(phoneNumberE164: String) async throws {
+        try await Task.sleep(nanoseconds: 500_000_000)
+    }
+
+    func verifyOTP(phoneNumberE164: String, code: String) async throws -> User {
+        try await Task.sleep(nanoseconds: 700_000_000)
+        guard code.count >= 4 else { throw AuthError.invalidCode }
+        return User(id: "me", displayName: "+" + phoneNumberE164.suffix(4), phoneNumberE164: phoneNumberE164)
+    }
+}
+

--- a/ios/Services/PushService.swift
+++ b/ios/Services/PushService.swift
@@ -1,0 +1,33 @@
+import Foundation
+import UIKit
+import UserNotifications
+
+final class PushService: NSObject {
+    static let shared = PushService()
+
+    private(set) var deviceTokenHex: String?
+
+    func requestAuthorizationAndRegister() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
+            DispatchQueue.main.async {
+                if granted {
+                    UIApplication.shared.registerForRemoteNotifications()
+                } else if let error = error {
+                    print("Push authorization error: \(error)")
+                }
+            }
+        }
+    }
+
+    func didRegisterForRemoteNotifications(deviceToken: Data) {
+        let token = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
+        self.deviceTokenHex = token
+        print("APNS token: \(token)")
+        // TODO: Send token to backend
+    }
+
+    func didFailToRegisterForRemoteNotifications(error: Error) {
+        print("Failed to register for remote notifications: \(error)")
+    }
+}
+

--- a/ios/ViewModels/ChatViewModel.swift
+++ b/ios/ViewModels/ChatViewModel.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+@MainActor
+final class ChatViewModel: ObservableObject {
+    let conversation: Conversation
+
+    @Published var inputText: String = ""
+    @Published var messages: [Message] = []
+    @Published var isSending: Bool = false
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String? = nil
+
+    private let messagingService: MessagingServiceProtocol
+    let sessionManager: SessionManager
+
+    init(conversation: Conversation, messagingService: MessagingServiceProtocol, sessionManager: SessionManager) {
+        self.conversation = conversation
+        self.messagingService = messagingService
+        self.sessionManager = sessionManager
+        Task { await loadMessages() }
+    }
+
+    var currentUserId: String? { sessionManager.currentUser?.id }
+
+    func loadMessages() async {
+        errorMessage = nil
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            messages = try await messagingService.loadMessages(conversationId: conversation.id)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func send() async {
+        guard let userId = currentUserId, !inputText.isEmpty else { return }
+        errorMessage = nil
+        isSending = true
+        let text = inputText
+        inputText = ""
+        defer { isSending = false }
+        do {
+            let message = try await messagingService.sendMessage(conversationId: conversation.id, senderId: userId, text: text)
+            messages.append(message)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+

--- a/ios/ViewModels/ConversationsViewModel.swift
+++ b/ios/ViewModels/ConversationsViewModel.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+@MainActor
+final class ConversationsViewModel: ObservableObject {
+    @Published var conversations: [Conversation] = []
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String? = nil
+
+    private let messagingService: MessagingServiceProtocol
+
+    init(messagingService: MessagingServiceProtocol) {
+        self.messagingService = messagingService
+        Task { await refresh() }
+    }
+
+    func refresh() async {
+        errorMessage = nil
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            conversations = try await messagingService.loadConversations()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func makeChatViewModel(for conversation: Conversation, sessionManager: SessionManager) -> ChatViewModel {
+        ChatViewModel(conversation: conversation, messagingService: messagingService, sessionManager: sessionManager)
+    }
+
+    func makeGroupCreationViewModel() -> GroupCreationViewModel {
+        GroupCreationViewModel(messagingService: messagingService)
+    }
+}
+

--- a/ios/ViewModels/GroupCreationViewModel.swift
+++ b/ios/ViewModels/GroupCreationViewModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+@MainActor
+final class GroupCreationViewModel: ObservableObject {
+    @Published var title: String = ""
+    @Published var participantIdsCSV: String = ""
+    @Published var isCreating: Bool = false
+    @Published var errorMessage: String? = nil
+
+    private let messagingService: MessagingServiceProtocol
+
+    init(messagingService: MessagingServiceProtocol) {
+        self.messagingService = messagingService
+    }
+
+    func createGroup() async throws -> Conversation? {
+        guard !title.isEmpty else { return nil }
+        let ids = participantIdsCSV.split(separator: ",").map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
+        isCreating = true
+        defer { isCreating = false }
+        do {
+            let conv = try await messagingService.createGroup(title: title, participantIds: ids)
+            return conv
+        } catch {
+            errorMessage = error.localizedDescription
+            return nil
+        }
+    }
+}
+

--- a/ios/ViewModels/OTPLoginViewModel.swift
+++ b/ios/ViewModels/OTPLoginViewModel.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+@MainActor
+final class OTPLoginViewModel: ObservableObject {
+    @Published var phoneNumberE164: String = ""
+    @Published var code: String = ""
+    @Published var isRequesting: Bool = false
+    @Published var isVerifying: Bool = false
+    @Published var errorMessage: String? = nil
+    @Published var otpRequested: Bool = false
+
+    private let authService: OTPAuthServiceProtocol
+    private let sessionManager: SessionManager
+
+    init(authService: OTPAuthServiceProtocol, sessionManager: SessionManager) {
+        self.authService = authService
+        self.sessionManager = sessionManager
+    }
+
+    func requestOTP() async {
+        errorMessage = nil
+        isRequesting = true
+        defer { isRequesting = false }
+        do {
+            try await authService.requestOTP(phoneNumberE164: phoneNumberE164)
+            otpRequested = true
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func verify() async {
+        errorMessage = nil
+        isVerifying = true
+        defer { isVerifying = false }
+        do {
+            let user = try await authService.verifyOTP(phoneNumberE164: phoneNumberE164, code: code)
+            sessionManager.signIn(user: user)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+

--- a/ios/ViewModels/SessionManager.swift
+++ b/ios/ViewModels/SessionManager.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+final class SessionManager: ObservableObject {
+    @Published var currentUser: User? = nil
+
+    var isAuthenticated: Bool { currentUser != nil }
+
+    func signIn(user: User) {
+        currentUser = user
+    }
+
+    func signOut() {
+        currentUser = nil
+    }
+}
+

--- a/ios/Views/ChatView.swift
+++ b/ios/Views/ChatView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct ChatView: View {
+    @StateObject var vm: ChatViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollViewReader { proxy in
+                List(vm.messages) { message in
+                    HStack {
+                        if message.senderId == vm.currentUserId { Spacer() }
+                        Text(message.plaintext ?? "…")
+                            .padding(8)
+                            .background(message.senderId == vm.currentUserId ? Color.blue.opacity(0.2) : Color.gray.opacity(0.2))
+                            .cornerRadius(8)
+                        if message.senderId != vm.currentUserId { Spacer() }
+                    }
+                    .listRowSeparator(.hidden)
+                }
+                .listStyle(.plain)
+            }
+
+            HStack {
+                TextField("Message", text: $vm.inputText)
+                    .textFieldStyle(.roundedBorder)
+                Button(action: { Task { await vm.send() } }) {
+                    if vm.isSending { ProgressView() } else { Image(systemName: "paperplane.fill") }
+                }
+                .disabled(vm.inputText.isEmpty)
+            }
+            .padding()
+        }
+        .navigationTitle(vm.conversation.title)
+    }
+}
+
+struct ChatView_Previews: PreviewProvider {
+    static var previews: some View {
+        let conversation = Conversation(id: UUID().uuidString, title: "General", isGroup: true, participantIds: ["me", "u1"], lastMessagePreview: nil, updatedAt: Date())
+        let sessionManager = SessionManager()
+        sessionManager.signIn(user: User(id: "me", displayName: "Me", phoneNumberE164: "+10000000000"))
+        let messaging = InMemoryMessagingService(encryptionService: LibSignalEncryptionService())
+        let vm = ChatViewModel(conversation: conversation, messagingService: messaging, sessionManager: sessionManager)
+        return NavigationView { ChatView(vm: vm) }
+    }
+}
+

--- a/ios/Views/ConversationsListView.swift
+++ b/ios/Views/ConversationsListView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct ConversationsListView: View {
+    @EnvironmentObject var vm: ConversationsViewModel
+    @EnvironmentObject var sessionManager: SessionManager
+
+    @State private var showCreateGroup = false
+
+    var body: some View {
+        NavigationView {
+            List(vm.conversations) { conv in
+                NavigationLink(destination: ChatView(vm: vm.makeChatViewModel(for: conv, sessionManager: sessionManager))) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text(conv.title).font(.headline)
+                            if conv.isGroup { Text("Group").font(.caption).foregroundColor(.secondary) }
+                        }
+                        if let preview = conv.lastMessagePreview {
+                            Text(preview).font(.subheadline).foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+            .overlay(Group { if vm.isLoading { ProgressView() } })
+            .navigationTitle("Chats")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showCreateGroup = true }) { Image(systemName: "person.3.fill") }
+                }
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Sign out") { sessionManager.signOut() }
+                }
+            }
+            .sheet(isPresented: $showCreateGroup) {
+                GroupCreationView(vm: vm.makeGroupCreationViewModel())
+            }
+        }
+    }
+}
+
+struct ConversationsListView_Previews: PreviewProvider {
+    static var previews: some View {
+        let vm = ConversationsViewModel(messagingService: InMemoryMessagingService(encryptionService: LibSignalEncryptionService()))
+        let sm = SessionManager()
+        sm.signIn(user: User(id: "me", displayName: "Me", phoneNumberE164: "+10000000000"))
+        return ConversationsListView()
+            .environmentObject(vm)
+            .environmentObject(sm)
+    }
+}
+

--- a/ios/Views/GroupCreationView.swift
+++ b/ios/Views/GroupCreationView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct GroupCreationView: View {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject var vm: GroupCreationViewModel
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Group Title")) {
+                    TextField("Team Plan", text: $vm.title)
+                }
+                Section(header: Text("Participants (comma-separated IDs)")) {
+                    TextField("u1,u2", text: $vm.participantIdsCSV)
+                }
+                if let error = vm.errorMessage {
+                    Text(error).foregroundColor(.red)
+                }
+                Section {
+                    Button(action: { Task {
+                        _ = try? await vm.createGroup()
+                        dismiss()
+                    }}) {
+                        if vm.isCreating { ProgressView() } else { Text("Create Group") }
+                    }
+                    .disabled(vm.title.isEmpty || vm.isCreating)
+                }
+            }
+            .navigationTitle("New Group")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) { Button("Cancel") { dismiss() } }
+            }
+        }
+    }
+}
+
+struct GroupCreationView_Previews: PreviewProvider {
+    static var previews: some View {
+        GroupCreationView(vm: GroupCreationViewModel(messagingService: InMemoryMessagingService(encryptionService: LibSignalEncryptionService())))
+    }
+}
+

--- a/ios/Views/OTPLoginView.swift
+++ b/ios/Views/OTPLoginView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct OTPLoginView: View {
+    @EnvironmentObject var vm: OTPLoginViewModel
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Phone Number")) {
+                    TextField("+1234567890", text: $vm.phoneNumberE164)
+                        .keyboardType(.phonePad)
+                        .textInputAutocapitalization(.never)
+                }
+
+                if vm.otpRequested {
+                    Section(header: Text("Verification Code")) {
+                        TextField("123456", text: $vm.code)
+                            .keyboardType(.numberPad)
+                    }
+                }
+
+                if let error = vm.errorMessage {
+                    Text(error).foregroundColor(.red)
+                }
+
+                Section {
+                    if !vm.otpRequested {
+                        Button(action: { Task { await vm.requestOTP() } }) {
+                            if vm.isRequesting { ProgressView() } else { Text("Request OTP") }
+                        }
+                        .disabled(vm.phoneNumberE164.isEmpty || vm.isRequesting)
+                    } else {
+                        Button(action: { Task { await vm.verify() } }) {
+                            if vm.isVerifying { ProgressView() } else { Text("Verify") }
+                        }
+                        .disabled(vm.code.isEmpty || vm.isVerifying)
+                    }
+                }
+            }
+            .navigationTitle("Sign in")
+        }
+    }
+}
+
+struct OTPLoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        OTPLoginView()
+            .environmentObject(OTPLoginViewModel(authService: MockOTPAuthService(), sessionManager: SessionManager()))
+    }
+}
+

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,3 +1,35 @@
+name: Agent3Chat
+options:
+  minimumXcodeGenVersion: 2.38.0
+  deploymentTarget:
+    iOS: 16.0
+packages:
+  LibSignalClient:
+    url: https://github.com/signalapp/libsignal-client
+    branch: main
+targets:
+  Agent3Chat:
+    type: application
+    platform: iOS
+    deploymentTarget: 16.0
+    sources:
+      - path: App
+      - path: Models
+      - path: Services
+      - path: ViewModels
+      - path: Views
+      - path: Resources
+    info:
+      path: Config/Info.plist
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.agent3chat
+        CODE_SIGN_ENTITLEMENTS: Config/App.entitlements
+        CURRENT_PROJECT_VERSION: 1
+        MARKETING_VERSION: 0.1.0
+    dependencies:
+      - package: LibSignalClient
+        product: LibSignalClient
 name: ChatApp
 options:
   deploymentTarget:


### PR DESCRIPTION
Scaffold initial iOS chat application with OTP login, group chat UI, push notifications, and a libsignal-client dependency.

This PR sets up the core iOS project structure, including XcodeGen configuration, `Info.plist`, entitlements, and the basic app shell. It integrates a mock OTP login flow, an in-memory messaging service with a placeholder `libsignal-client` encryption service, and UI for conversations, chat, and group creation. Push notification registration is also wired.

---
<a href="https://cursor.com/background-agent?bcId=bc-76031dba-bbac-444e-945c-583e51e01d71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-76031dba-bbac-444e-945c-583e51e01d71">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

