### PR TITLE
Protect moderation service api routes

### DIFF
--- a/moderation_service/requirements.txt
+++ b/moderation_service/requirements.txt
@@ -5,3 +5,4 @@ jinja2>=3.1
 sqlmodel==0.0.22
 alembic==1.13.3
 prometheus-client==0.20.0
+python-jose[cryptography]>=3.3.0


### PR DESCRIPTION
Add JWT authentication to moderation service routes to protect all endpoints except `/health`.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd12efba-73bc-44bb-a9d8-0cc9b4c6caea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cd12efba-73bc-44bb-a9d8-0cc9b4c6caea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

