### PR TITLE
Protect moderation service api routes

### DIFF
--- a/moderation_service/requirements.txt
+++ b/moderation_service/requirements.txt
@@ -5,3 +5,4 @@ jinja2>=3.1
 sqlmodel==0.0.22
 alembic==1.13.3
 prometheus-client==0.20.0
+PyJWT>=2.9


### PR DESCRIPTION
Add JWT authentication to all moderation service routes except `/health` to protect them.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d9e0002-59c1-411f-a703-30053d97dda8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d9e0002-59c1-411f-a703-30053d97dda8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

