### PR TITLE
Debug slow npm tests and isolate service issues

### DIFF
--- a/agent7-messaging/vitest.config.ts
+++ b/agent7-messaging/vitest.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
 		globals: true,
 		environment: 'node',
 		coverage: { reporter: ['text', 'lcov'] },
+		include: ['test/**/*.test.ts'],
+		exclude: ['**/*.test.js', '**/node_modules/**', '**/dist/**'],
 	},
 });
 

--- a/src/test/Footer.test.tsx
+++ b/src/test/Footer.test.tsx
@@ -14,8 +14,8 @@ describe('Footer Component', () => {
       </WithRouter>
     );
 
-    // Check for the brand name
-    expect(screen.getByRole('heading', { name: /iKasiLink/i })).toBeInTheDocument();
+    // Check for the brand name (exact match to avoid "iKasiLink Platform")
+    expect(screen.getByRole('heading', { name: /^iKasiLink$/i })).toBeInTheDocument();
     
     // Check for copyright notice
     expect(screen.getByText(/© 2024 iKasiLink/i)).toBeInTheDocument();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     globals: true,
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Fix Vitest configurations and a test assertion to enable isolated and successful test runs.

This PR addresses issues where the root Vitest runner was picking up subpackage tests, `agent7-messaging` Vitest was failing due to compiled `.js` test files, and a `Footer.test.tsx` assertion was too broad.

---
<a href="https://cursor.com/background-agent?bcId=bc-146dfd55-a19d-4add-865b-83ba04c6a1f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-146dfd55-a19d-4add-865b-83ba04c6a1f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

