### PR TITLE
Fix footer test selectors

### DIFF
--- a/src/test/Footer.test.tsx
+++ b/src/test/Footer.test.tsx
@@ -13,9 +13,10 @@ describe('Footer Component', () => {
         <Footer />
       </WithRouter>
     );
-
-    // Check for the brand name
-    expect(screen.getByRole('heading', { name: /iKasiLink/i })).toBeInTheDocument();
+    // Check for the brand name specifically in the brand section (h3)
+    expect(
+      screen.getByRole('heading', { level: 3, name: /iKasiLink/i })
+    ).toBeInTheDocument();
     
     // Check for copyright notice
     expect(screen.getByText(/© 2024 iKasiLink/i)).toBeInTheDocument();


### PR DESCRIPTION
Update `Footer.test.tsx` to use a more specific selector for the "iKasiLink" heading to resolve test failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-9688680d-9d01-42df-a544-f521dda462f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9688680d-9d01-42df-a544-f521dda462f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

