### PR TITLE
Fix moderation queue re-render and escalation timeouts

### DIFF
--- a/src/test/Footer.test.tsx
+++ b/src/test/Footer.test.tsx
@@ -14,8 +14,8 @@ describe('Footer Component', () => {
       </WithRouter>
     );
 
-    // Check for the brand name
-    expect(screen.getByRole('heading', { name: /iKasiLink/i })).toBeInTheDocument();
+    // Check for the brand name (target the main brand h3, not section h4)
+    expect(screen.getByRole('heading', { level: 3, name: /^iKasiLink$/i })).toBeInTheDocument();
     
     // Check for copyright notice
     expect(screen.getByText(/© 2024 iKasiLink/i)).toBeInTheDocument();


### PR DESCRIPTION
Update Footer test to use a specific heading query to resolve an ambiguous heading assertion.

---
<a href="https://cursor.com/background-agent?bcId=bc-aebb01d0-1606-4811-b604-58a84bbffef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aebb01d0-1606-4811-b604-58a84bbffef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

